### PR TITLE
Add Note Pydantic models for create and read operationsAdd NoteCreate and Note Pydantic models

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class NoteBase(BaseModel):
+    """Fields shared between note creation requests and full note representation."""
+    title: str = Field(min_length=1, max_length=200)
+    content: str = Field(min_length=1, max_length=10_000)
+
+
+class NoteCreate(NoteBase):
+    """Shape of the data a client sends to create a new note.
+
+    Server-generated fields (id, created_at, updated_at) are deliberately
+    excluded — clients don't get to set those.
+    """
+    pass
+
+
+class Note(NoteBase):
+    """Full representation of a note, including server-generated fields.
+
+    This is what the server returns to clients. `from_attributes=True`
+    allows construction from ORM objects in addition to dicts.
+    """
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    created_at: datetime
+    updated_at: datetime


### PR DESCRIPTION
## What
Introduces two Pydantic models in `models.py`:
- `NoteCreate`: the shape clients send when creating a note (title, content only).
- `Note`: the full representation including server-generated fields (id, created_at, updated_at).

## Why
Sets up the data foundation needed before implementing the notes endpoints.
Splitting create vs. full-read shapes prevents clients from setting server-owned fields.

## How
- New `models.py` module to keep data models separate from app/route code.
- Both models inherit from `pydantic.BaseModel` for automatic validation.
- Docstrings explain the *why* of each model's shape.

## Testing
No runtime behavior changed yet — these models will be wired into endpoints in a follow-up PR.
Manually verified that `models.py` imports cleanly with `uv run python -c "import models"`.