### PR TITLE
Add list and create endpoints for notes

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,26 +1,26 @@
 from datetime import datetime, timezone
 
-from fastapi import FastAPI
+from fastapi import FastAPI, status
 
 from models import Note, NoteCreate
 
 app = FastAPI(title="Notes API", version="0.1.0")
 
-# In-memory storage. Will be replaced with a database in a future PR.
-# TODO: Replace with database-generated IDs. Current approach is not safe
-#   under concurrent requests or multiple server instances.
+# TODO: Replace with database-generated IDs. The current approach is not
+#   safe across multiple server instances, and is only race-free here
+#   because the handlers are `async def` (running on a single event loop).
 notes_db: list[Note] = []
 next_id: int = 1
 
 
 @app.get("/notes", response_model=list[Note])
-def list_notes() -> list[Note]:
+async def list_notes() -> list[Note]:
     """Return all notes currently stored."""
     return notes_db
 
 
-@app.post("/notes", response_model=Note, status_code=201)
-def create_note(note_in: NoteCreate) -> Note:
+@app.post("/notes", response_model=Note, status_code=status.HTTP_201_CREATED)
+async def create_note(note_in: NoteCreate) -> Note:
     """Create a new note from the provided title and content."""
     global next_id
     now = datetime.now(timezone.utc)

--- a/main.py
+++ b/main.py
@@ -1,8 +1,36 @@
+from datetime import datetime, timezone
+
 from fastapi import FastAPI
 
-app = FastAPI()
+from models import Note, NoteCreate
 
-@app.get("/")
-async def read_root():
-    return {"message": "Hello, FastAPI!"}
+app = FastAPI(title="Notes API", version="0.1.0")
 
+# In-memory storage. Will be replaced with a database in a future PR.
+# TODO: Replace with database-generated IDs. Current approach is not safe
+#   under concurrent requests or multiple server instances.
+notes_db: list[Note] = []
+next_id: int = 1
+
+
+@app.get("/notes", response_model=list[Note])
+def list_notes() -> list[Note]:
+    """Return all notes currently stored."""
+    return notes_db
+
+
+@app.post("/notes", response_model=Note, status_code=201)
+def create_note(note_in: NoteCreate) -> Note:
+    """Create a new note from the provided title and content."""
+    global next_id
+    now = datetime.now(timezone.utc)
+    new_note = Note(
+        id=next_id,
+        title=note_in.title,
+        content=note_in.content,
+        created_at=now,
+        updated_at=now,
+    )
+    notes_db.append(new_note)
+    next_id += 1
+    return new_note

--- a/models.py
+++ b/models.py
@@ -25,7 +25,10 @@ class Note(NoteBase):
 
     `from_attributes=True` allows construction from ORM objects in addition to dicts.
     """
+    # Pydantic config is replaced (not merged) on inheritance, so we restate
+    # extra="forbid" alongside from_attributes=True.
     model_config = ConfigDict(extra="forbid", from_attributes=True)
+   
 
     id: int
     created_at: datetime

--- a/models.py
+++ b/models.py
@@ -5,6 +5,8 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class NoteBase(BaseModel):
     """Fields shared between note creation requests and full note representation."""
+    model_config = ConfigDict(extra="forbid")
+
     title: str = Field(min_length=1, max_length=200)
     content: str = Field(min_length=1, max_length=10_000)
 
@@ -21,10 +23,9 @@ class NoteCreate(NoteBase):
 class Note(NoteBase):
     """Full representation of a note, including server-generated fields.
 
-    This is what the server returns to clients. `from_attributes=True`
-    allows construction from ORM objects in addition to dicts.
+    `from_attributes=True` allows construction from ORM objects in addition to dicts.
     """
-    model_config = ConfigDict(from_attributes=True)
+    model_config = ConfigDict(extra="forbid", from_attributes=True)
 
     id: int
     created_at: datetime


### PR DESCRIPTION
## What
Implements the first two notes endpoints:
- `GET /notes` — returns all stored notes
- `POST /notes` — creates a new note from `{title, content}`, returns full Note with server-generated id and timestamps

Also tightens the data models to reject unknown fields, preventing
silent acceptance of client-supplied values for server-owned fields.

## Why
First runnable API surface. Establishes the in-memory storage pattern
we'll later replace with a real database.

The `extra="forbid"` change closes a small but real category of bug —
clients sending fields the server shouldn't accept (e.g. `id`) are now
loudly rejected rather than silently ignored.

## How
- Endpoints live in `main.py` for now; will split into `routes.py` /
  `APIRouter` once we have multiple resources.
- IDs are sequential ints from a `global next_id` counter — explicitly
  marked TODO. Will move to DB-generated IDs in a follow-up PR. Not safe
  under concurrent requests or multi-instance deployment, acceptable for
  single-process dev work.
- Timestamps use `datetime.now(timezone.utc)` — UTC, timezone-aware,
  ISO 8601 serialized.

## Testing
Manually verified via Swagger UI at `/docs`:
- `POST /notes` with valid body returns 201 with full Note.
- `GET /notes` returns the list.
- Validation rejects: empty title, missing content, wrong type, extra fields.
- `id` field in request body is now rejected with 422 (was silently dropped before).