### PR TITLE
Add GET, PUT, and DELETE endpoints for individual notes

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,6 @@
 from datetime import datetime, timezone
 
-from fastapi import FastAPI, status
+from fastapi import FastAPI, HTTPException, status
 
 from models import Note, NoteCreate
 
@@ -13,10 +13,31 @@ notes_db: list[Note] = []
 next_id: int = 1
 
 
+# helper function to find a note by ID
+def find_note_by_id(note_id: int) -> Note | None:
+    """Return the note with the given id, or None if not found."""
+    for note in notes_db:
+        if note.id == note_id:
+            return note
+    return None
+
+
 @app.get("/notes", response_model=list[Note])
 async def list_notes() -> list[Note]:
     """Return all notes currently stored."""
     return notes_db
+
+
+@app.get("/notes/{note_id}", response_model=Note)
+async def get_note(note_id: int) -> Note:
+    """Return the note with the given id, or 404 if not found."""
+    note = find_note_by_id(note_id)
+    if note is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Note with id {note_id} not found",
+        )
+    return note
 
 
 @app.post("/notes", response_model=Note, status_code=status.HTTP_201_CREATED)

--- a/main.py
+++ b/main.py
@@ -55,3 +55,31 @@ async def create_note(note_in: NoteCreate) -> Note:
     notes_db.append(new_note)
     next_id += 1
     return new_note
+
+
+@app.put("/notes/{note_id}", response_model=Note)
+async def update_note(note_id: int, note_in: NoteCreate) -> Note:
+    """Replace an existing note's title and content. Returns 404 if not found."""
+    existing = find_note_by_id(note_id)
+    if existing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Note with id {note_id} not found",
+        )
+    existing.title = note_in.title
+    existing.content = note_in.content
+    existing.updated_at = datetime.now(timezone.utc)
+    return existing
+
+
+@app.delete("/notes/{note_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_note(note_id: int) -> None:
+    """Delete the note with the given id. Returns 404 if not found."""
+    existing = find_note_by_id(note_id)
+    if existing is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Note with id {note_id} not found",
+        )
+    notes_db.remove(existing)
+    return None

--- a/models.py
+++ b/models.py
@@ -5,7 +5,10 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class NoteBase(BaseModel):
     """Fields shared between note creation requests and full note representation."""
-    model_config = ConfigDict(extra="forbid") # Forbid extra fields in all subclasses by default. Means clients can't send fields we don't expect, and we don't accidentally allow them to set server-generated fields like `id` or `created_at` in create/update requests.
+
+    model_config = ConfigDict(
+        extra="forbid"
+    )  # Forbid extra fields in all subclasses by default. Means clients can't send fields we don't expect, and we don't accidentally allow them to set server-generated fields like `id` or `created_at` in create/update requests.
 
     title: str = Field(min_length=1, max_length=200)
     content: str = Field(min_length=1, max_length=10_000)
@@ -17,6 +20,7 @@ class NoteCreate(NoteBase):
     Server-generated fields (id, created_at, updated_at) are deliberately
     excluded — clients don't get to set those.
     """
+
     pass
 
 
@@ -25,10 +29,10 @@ class Note(NoteBase):
 
     `from_attributes=True` allows construction from ORM objects in addition to dicts.
     """
+
     # Pydantic config is replaced (not merged) on inheritance, so we restate
     # extra="forbid" alongside from_attributes=True.
     model_config = ConfigDict(extra="forbid", from_attributes=True)
-   
 
     id: int
     created_at: datetime

--- a/models.py
+++ b/models.py
@@ -5,7 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 class NoteBase(BaseModel):
     """Fields shared between note creation requests and full note representation."""
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid") # Forbid extra fields in all subclasses by default. Means clients can't send fields we don't expect, and we don't accidentally allow them to set server-generated fields like `id` or `created_at` in create/update requests.
 
     title: str = Field(min_length=1, max_length=200)
     content: str = Field(min_length=1, max_length=10_000)


### PR DESCRIPTION
## What

Completes the per-note CRUD endpoints:

- `GET /notes/{id}` — fetch a single note by id
- `PUT /notes/{id}` — full replacement of `title` and `content`, preserving `id` and `created_at` and bumping `updated_at`
- `DELETE /notes/{id}` — remove a note, returns 204 with no body

Also extracts a small `find_note_by_id` helper to centralize lookup so
the GET, PUT, and DELETE paths share the same not-found behavior.

## Why

Closes the CRUD set for the in-memory phase. With list, create, read,
update, and delete all in place, the API is feature-complete at the
data level — which is the right point to layer on real persistence
and an automated test suite next, instead of doing it piecemeal
alongside endpoint work.

## How

- Missing notes raise `HTTPException(status_code=404)` rather than
  returning `None` or an empty body — gives a clean 404 response
  with a `detail` message in the standard FastAPI shape.
- `PUT` is a full replacement, not a partial update: the request
  body is `NoteCreate` (title + content), and the server
  reconstructs a `Note` that keeps the original `id` and
  `created_at` while stamping a fresh `updated_at`. PATCH-style
  partial updates are deferred — see #10.
- `DELETE` returns `status_code=204` with no response body so
  FastAPI doesn't try to serialize one. The handler returns
  nothing on success.
- `find_note_by_id` is defined once and reused by all three new
  routes. Keeps the 404 logic in one place — if we want to change
  the error message or status later, it's a single edit.

## Testing

Manually verified via Swagger UI at `/docs`. The most interesting
case is PUT preserving server-owned fields:

1. POST a note → `id=1`, `created_at=2026-05-10T09:52:30Z`,
   `updated_at=2026-05-10T09:52:30Z` (equal, as expected on create).
2. Wait a few hours, then PUT `/notes/1` with new title + content.
3. Response: `id=1` (unchanged), `created_at=2026-05-10T09:52:30Z`
   (unchanged), `updated_at=2026-05-10T11:55:46Z` (refreshed).

That `created_at` vs `updated_at` divergence — with `id` held
constant — is the actual evidence the replacement logic is correct,
not just that the endpoint returns 200.

Other paths verified:

- `GET /notes/{id}` with valid id → 200 with the note.
- `GET /notes/{id}` with missing id → 404 with `detail` message.
- `GET /notes/abc` (non-integer) → 422 with type validation error.
- `PUT /notes/{id}` with missing id → 404 (no partial state mutation).
- `DELETE /notes/{id}` with valid id → 204, no body, subsequent
  `GET /notes/{id}` returns 404.
- `DELETE /notes/{id}` with missing id → 404.

## Doesn't address

Intentionally out of scope, tracked elsewhere:

- PATCH for partial updates — #10
- Pagination on `GET /notes` — #6
- `Location` header on POST/PUT responses — #7
- Automated test suite (pytest + httpx) — #8

These come after persistence lands so we're not rewriting tests
against the in-memory store and then immediately rewriting them
again against the database.